### PR TITLE
Add unit testing to all database functions on the sqlite driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "chrono",
  "futures",
  "ipnet",
+ "md5",
  "serde",
  "sqlx",
  "test-log",
@@ -1248,6 +1249,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +73,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -367,6 +425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +526,7 @@ dependencies = [
  "ipnet",
  "serde",
  "sqlx",
+ "test-log",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -522,6 +587,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -1055,6 +1141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1223,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -1577,6 +1678,50 @@ checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -2255,6 +2400,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "textnonce"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,10 +2722,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2706,6 +2877,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite", "macros", "json", "uuid", "ipnetwork", "chrono", "migrate" ] }
 uuid = { version = "1.5.0", features = ["v4", "fast-rng", "serde" ] }
 chrono = { version = "^0.4", features = [ "serde" ] }
+md5 = { version = "0.7.0" }
 futures = "0.3.30"
 ipnet = "2.9.0"
 serde = { version = "1.0.193", features = ["derive"] }

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -12,4 +12,5 @@ ipnet = "2.9.0"
 serde = { version = "1.0.193", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
+test-log = { version = "0.2.16", features = ["trace"] }
 bcrypt = "0.15.0"

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -84,7 +84,7 @@ pub enum ModpackSource {
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct Blacklist {
-    pub when: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
     pub actor: Json<BanActor>,
     pub hits: i64,
     pub(crate) base_ip: u32,

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -29,6 +29,7 @@ pub(crate) struct Account {
 #[derive(sqlx::FromRow, Debug)]
 pub(crate) struct Allowlist {
     pub(crate) uuid: Uuid,
+    pub(crate) discord_id: String,
     pub(crate) base_ip: u32,
     pub(crate) mask: u8,
     pub(crate) last_join: DateTime<Utc>,

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -135,11 +135,32 @@ pub struct Loc {
     pub z: f64,
 }
 
+impl Default for Loc {
+    fn default() -> Self {
+        Self {
+            dim: "minecraft:overworld".to_owned(),
+            x: 0.0,
+            y: 64.0,
+            z: 0.0,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Viewport {
     pub loc: Loc,
     pub yaw: f64,
     pub pitch: f64,
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Self {
+            loc: Loc::default(),
+            yaw: 0.0,
+            pitch: 0.0,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -127,7 +127,7 @@ pub enum BanActor {
     Staff(Uuid),
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Loc {
     pub dim: String,
     pub x: f64,
@@ -146,7 +146,7 @@ impl Default for Loc {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Viewport {
     pub loc: Loc,
     pub yaw: f64,

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -127,7 +127,7 @@ pub enum BanActor {
     Staff(Uuid),
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Loc {
     pub dim: String,
     pub x: f64,
@@ -146,7 +146,7 @@ impl Default for Loc {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Viewport {
     pub loc: Loc,
     pub yaw: f64,

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -51,8 +51,9 @@ impl NetworkProvider for Allowlist {
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct SaveData {
-    pub user_id: Uuid,
-    pub server_id: Uuid,
+    pub player_uuid: Uuid,
+    pub server_uuid: Uuid,
+    pub player_discord_id: String,
     pub viewport: Json<Viewport>,
     pub playtime: Json<Duration>,
 }

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -57,7 +57,7 @@ pub struct SaveData {
     pub playtime: Json<Duration>,
 }
 
-#[derive(sqlx::FromRow, Debug)]
+#[derive(sqlx::FromRow, Debug, PartialEq)]
 pub struct Server {
     pub uuid: Uuid,
     pub name: String,
@@ -67,7 +67,7 @@ pub struct Server {
     pub players: Json<Vec<Uuid>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Modpack {
     pub name: String,
     pub source: ModpackSource,
@@ -75,7 +75,7 @@ pub struct Modpack {
     pub uri: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum ModpackSource {
     Modrinth,
     Curseforge,

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -29,7 +29,6 @@ pub(crate) struct Account {
 #[derive(sqlx::FromRow, Debug)]
 pub(crate) struct Allowlist {
     pub(crate) uuid: Uuid,
-    pub(crate) discord_id: String,
     pub(crate) base_ip: u32,
     pub(crate) mask: u8,
     pub(crate) last_join: DateTime<Utc>,
@@ -54,7 +53,6 @@ impl NetworkProvider for Allowlist {
 pub struct SaveData {
     pub player_uuid: Uuid,
     pub server_uuid: Uuid,
-    pub player_discord_id: String,
     pub viewport: Json<Viewport>,
     pub playtime: Json<Duration>,
 }

--- a/db/src/data.rs
+++ b/db/src/data.rs
@@ -142,7 +142,7 @@ pub struct Viewport {
     pub pitch: f64,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Pronoun {
     pub pronoun: String,
     pub color: String,

--- a/db/src/drivers.rs
+++ b/db/src/drivers.rs
@@ -8,6 +8,7 @@ pub mod err {
         use uuid::Uuid;
 
         /// When information can't be found on the database.
+        #[derive(Debug)]
         pub enum NotFoundError {
             Server, // Equivalent to: Server{Join,Leave}::InvalidServer, {Viewport,Playtime}Update::InvalidServer
             User(Uuid), // Equivalent to: Server{Join,Leave}::InvalidUser, {Viewport,Playtime}Update::InvalidUser
@@ -20,16 +21,19 @@ pub mod err {
         }
 
         /// When user input is invalid.
+        #[derive(Debug)]
         pub enum InvalidError {
             Password, // Equivalent to: Password{Check,Modify}::InvalidPassword
             OldPassword, // Didn't exist.
         }
 
+        #[derive(Debug)]
         pub enum PermissionError {
             AutomatedSystem, // Equivalent to: PardonAttempt::InsufficientPermissions
         }
     }
 
+    #[derive(Debug)]
     pub enum DriverError {
         DatabaseError(base::NotFoundError),
         DuplicateKeyInsertion,

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -476,7 +476,7 @@ impl DataSource for Sqlite {
             .bind(Json(stub.supported_versions))
             .bind(Json(stub.current_modpack))
             .bind(Json(true))
-            .bind(Json("[]"))
+            .bind("[]")
 	    .fetch_one(&mut self.conn).await;
 
         map_or_log(query, DriverError::DuplicateKeyInsertion)

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -230,10 +230,9 @@ impl DataSource for Sqlite {
         let user = self.get_account(player_uuid).await?;
 
         let query = sqlx::query_as::<_, Allowlist>(
-            "INSERT INTO allowlist (uuid, discord_id, base_ip, mask, last_join, hits) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *"
+            "INSERT INTO allowlist (uuid, base_ip, mask, last_join, hits) VALUES ($1, $2, $3, $4, $5) RETURNING *"
         )
         .bind(player_uuid)
-        .bind(user.discord_id)
         .bind(ip.to_bits())
         .bind(32)
         .bind(Utc::now())

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -227,10 +227,13 @@ impl DataSource for Sqlite {
     /// Returns an [`DriverError::DuplicateKeyInsertion`] if an account with the given uuid or ip address can be found.
     #[tracing::instrument(skip(ip))]
     async fn create_allowlist(&mut self, player_uuid: &Uuid, ip: Ipv4Addr) -> Response<Allowlist> {
+        let user = self.get_user_by_uuid(player_uuid).await?;
+
         let query = sqlx::query_as::<_, Allowlist>(
-            "INSERT INTO allowlist (uuid, base_ip, mask, last_join, hits) VALUES ($1, $2, $3, $4, $5) RETURNING *"
+            "INSERT INTO allowlist (uuid, discord_id, base_ip, mask, last_join, hits) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *"
         )
         .bind(player_uuid)
+        .bind(user.discord_id)
         .bind(ip.to_bits())
         .bind(32)
         .bind(Utc::now())

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -250,7 +250,7 @@ impl DataSource for Sqlite {
     #[tracing::instrument]
     async fn get_allowlists(&mut self, player_uuid: &Uuid) -> Response<Vec<Allowlist>> {
         let query = sqlx::query_as::<_, Allowlist>(
-            "SELECT * FROM allowlist WHERE uuid = $1 SORT BY last_join DESC",
+            "SELECT * FROM allowlist WHERE uuid = $1 ORDER BY last_join DESC",
         )
         .bind(player_uuid)
         .fetch_all(&mut self.conn)
@@ -272,7 +272,7 @@ impl DataSource for Sqlite {
         ip: Ipv4Addr,
     ) -> Response<Vec<Allowlist>> {
         let query = sqlx::query_as::<_, Allowlist>(
-            "SELECT * FROM allowlist WHERE uuid = $1 AND ($2 & (-1 << (32 - mask))) = (base_ip & (-1 << (32 - mask))) SORT BY last_join DESC"
+            "SELECT * FROM allowlist WHERE uuid = $1 AND ($2 & (-1 << (32 - mask))) = (base_ip & (-1 << (32 - mask))) ORDER BY last_join DESC"
         )
         .bind(player_uuid)
         .bind(ip.to_bits())
@@ -296,7 +296,7 @@ impl DataSource for Sqlite {
         mask: u8,
     ) -> Response<Vec<Allowlist>> {
         let query = sqlx::query_as::<_, Allowlist>(
-            "SELECT * FROM allowlist WHERE uuid = $1 AND ($2 & (-1 << (32 - $3))) = (base_ip & (-1 << (32 - $3))) SORT BY last_join DESC"
+            "SELECT * FROM allowlist WHERE uuid = $1 AND ($2 & (-1 << (32 - $3))) = (base_ip & (-1 << (32 - $3))) ORDER BY last_join DESC"
         )
         .bind(player_uuid)
         .bind(ip.to_bits())
@@ -369,7 +369,7 @@ impl DataSource for Sqlite {
     #[tracing::instrument(skip(ip))]
     async fn get_blacklists(&mut self, ip: Ipv4Addr) -> Response<Vec<Blacklist>> {
         let query = sqlx::query_as::<_,Blacklist>(
-            "SELECT * FROM blacklist WHERE ($1 & (-1 << (32 - mask))) = (base_ip & (-1 << (32 - mask))) SORT BY hits DESC"
+            "SELECT * FROM blacklist WHERE ($1 & (-1 << (32 - mask))) = (base_ip & (-1 << (32 - mask))) ORDER BY hits DESC"
         )
         .bind(ip.to_bits())
         .fetch_all(&mut self.conn)
@@ -391,7 +391,7 @@ impl DataSource for Sqlite {
         mask: u8,
     ) -> Response<Vec<Blacklist>> {
         let query = sqlx::query_as::<_,Blacklist>(
-            "SELECT * FROM blacklist WHERE ($1 & (-1 << (32 - $2))) = (base_ip & (-1 << (32 - $2))) SORT BY hits DESC"
+            "SELECT * FROM blacklist WHERE ($1 & (-1 << (32 - $2))) = (base_ip & (-1 << (32 - $2))) ORDER BY hits DESC"
         )
         .bind(ip.to_bits())
         .fetch_all(&mut self.conn)

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -434,7 +434,7 @@ impl DataSource for Sqlite {
             .bind(entry.hits + 1)
             .bind(entry.base_ip)
             .bind(entry.mask)
-            .fetch_one(&mut self.conn)
+            .execute(&mut self.conn)
             .await;
 
         map_or_log(query.map(|_| ()), DriverError::Unreachable)
@@ -449,7 +449,7 @@ impl DataSource for Sqlite {
             .bind(new_mask)
             .bind(entry.base_ip)
             .bind(entry.mask)
-            .fetch_one(&mut self.conn)
+            .execute(&mut self.conn)
             .await;
 
         map_or_log(query.map(|_| ()), DriverError::Unreachable)

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -188,16 +188,16 @@ impl DataSource for Sqlite {
 
     /// Migrates an [`Account`]'s password to a new Account, returing the unit value on success.
     ///
-    /// Returns an [`base::NotFoundError::Account`] wrapped inside a [`DriverError::DatabaseError`] if either account with the provided uuid can't be found.  
+    /// Returns an [`base::NotFoundError::User`] wrapped inside a [`DriverError::DatabaseError`] if either user with the provided uuid can't be found.  
     /// Returns an [`DriverError::Unreachable`] if something *bad* happens.
     /// ### Note: Using [`DriverError::Unreachable`] is justified since all inputs were validated prior to running the query.
 
     #[tracing::instrument]
     async fn migrate_account(&mut self, from: &uuid::Uuid, to: &uuid::Uuid) -> Response<()> {
-        let from = self.get_account(from).await?;
-        let to = self.get_account(to).await?;
+        let from = self.get_user_by_uuid(from).await?;
+        let to = self.get_user_by_uuid(to).await?;
 
-        let query = sqlx::query("UPDATE accounts SET password = (SELECT password FROM accounts WHERE uuid = $1) WHERE uuid = $2")
+        let query = sqlx::query("UPDATE accounts SET uuid = $2 WHERE uuid = $1")
         .bind(from.uuid)
         .bind(to.uuid)
         .execute(&mut self.conn)

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -810,10 +810,9 @@ impl DataSource for Sqlite {
         let user = self.get_user_by_uuid(player_uuid).await?;
         let _ = self.get_server(server_uuid).await?;
 
-        let query = sqlx::query_as::<_, SaveData>("INSERT INTO savedata (server_uuid, player_uuid, player_discord_id, playtime, viewport) VALUES ($1, $2, $3, $4, $5) RETURNING *")
+        let query = sqlx::query_as::<_, SaveData>("INSERT INTO savedata (server_uuid, player_uuid, playtime, viewport) VALUES ($1, $2, $3, $4) RETURNING *")
             .bind(server_uuid)
             .bind(player_uuid)
-            .bind(user.discord_id)
             .bind(Json(time::Duration::ZERO))
             .bind(Json(Viewport::default()))
             .fetch_one(&mut self.conn)

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -612,7 +612,7 @@ impl DataSource for Sqlite {
         let _ = self.get_server(server_uuid).await?;
 
         let query = sqlx::query_as::<_,SaveData>(
-            "UPDATE savedata SET viewport = $1 WHERE player_uuid = $2 AND server_uuid = $2 RETURNING *"
+            "UPDATE savedata SET viewport = $1 WHERE player_uuid = $2 AND server_uuid = $3 RETURNING *"
         )
         .bind(Json(viewport))
         .bind(player_uuid)

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -394,6 +394,7 @@ impl DataSource for Sqlite {
             "SELECT * FROM blacklist WHERE ($1 & (-1 << (32 - $2))) = (base_ip & (-1 << (32 - $2))) ORDER BY hits DESC"
         )
         .bind(ip.to_bits())
+        .bind(mask)
         .fetch_all(&mut self.conn)
         .await;
 

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -311,13 +311,13 @@ impl DataSource for Sqlite {
 
     /// Bumps the `hits` field of an [`AllowlistEntry`].
     ///
-    /// Also updates the `last_joined` field to `Utc::now`.  
+    /// Also updates the `last_join` field to `Utc::now`.  
     /// Returns an [DriverError::Unreachable] if something *bad* happens.  
     /// ### Note: The use of unreachable is justified since this function should be used for modifying already existing input.
     #[tracing::instrument]
     async fn bump_allowlist(&mut self, entry: Allowlist) -> Response<()> {
         let query = sqlx::query(
-            "UPDATE allowlist SET hits = $1, last_joined = $2 WHERE uuid = $3 AND base_ip = $4",
+            "UPDATE allowlist SET hits = $1, last_join = $2 WHERE uuid = $3 AND base_ip = $4",
         )
         .bind(entry.hits + 1)
         .bind(Utc::now())

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -227,7 +227,7 @@ impl DataSource for Sqlite {
     /// Returns an [`DriverError::DuplicateKeyInsertion`] if an account with the given uuid or ip address can be found.
     #[tracing::instrument(skip(ip))]
     async fn create_allowlist(&mut self, player_uuid: &Uuid, ip: Ipv4Addr) -> Response<Allowlist> {
-        let user = self.get_user_by_uuid(player_uuid).await?;
+        let user = self.get_account(player_uuid).await?;
 
         let query = sqlx::query_as::<_, Allowlist>(
             "INSERT INTO allowlist (uuid, discord_id, base_ip, mask, last_join, hits) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *"

--- a/db/src/drivers/sqlite.rs
+++ b/db/src/drivers/sqlite.rs
@@ -795,7 +795,7 @@ impl DataSource for Sqlite {
     }
 
     /// Creates a [`SaveData`] for an [`User`] / [`Server`] pair.
-    /// 
+    ///
     /// Returns:
     /// - [`DriverError::DuplicateKeyInsertion`] if that user/server pair already existed.
     #[tracing::instrument]
@@ -804,16 +804,15 @@ impl DataSource for Sqlite {
         player_uuid: &Uuid,
         server_uuid: &Uuid,
     ) -> Response<SaveData> {
-        let query = sqlx::query_as::<_, SaveData>("INSERT INTO savedata (server_uuid, player_uuid, playtime, viewport) VALUES ($1, $2, $3, $4) RETURNING *")
+        let user = self.get_user_by_uuid(player_uuid).await?;
+        let _ = self.get_server(server_uuid).await?;
+
+        let query = sqlx::query_as::<_, SaveData>("INSERT INTO savedata (server_uuid, player_uuid, player_discord_id, playtime, viewport) VALUES ($1, $2, $3, $4, $5) RETURNING *")
             .bind(server_uuid)
             .bind(player_uuid)
+            .bind(user.discord_id)
             .bind(Json(time::Duration::ZERO))
-            .bind(Json(Viewport{ loc: Loc {
-                dim: "minecraft:overworld".to_owned(),
-                x: 0.0,
-                y: 64.0,
-                z: 0.0,
-            }, yaw: 0.0, pitch: 0.0 }))
+            .bind(Json(Viewport::default()))
             .fetch_one(&mut self.conn)
             .await;
 

--- a/db/src/migrations/01_create-user.sql
+++ b/db/src/migrations/01_create-user.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS users (
-    uuid TEXT NOT NULL,
+    uuid TEXT NOT NULL UNIQUE,
     discord_id TEXT NOT NULL,
     username TEXT UNIQUE,
     created_at DATE,

--- a/db/src/migrations/01_create-user.sql
+++ b/db/src/migrations/01_create-user.sql
@@ -6,5 +6,5 @@ CREATE TABLE IF NOT EXISTS users (
     pronouns TEXT,
     last_server TEXT,
 
-    PRIMARY KEY (uuid, discord_id)
+    PRIMARY KEY (uuid)
 );

--- a/db/src/migrations/02_create-account.sql
+++ b/db/src/migrations/02_create-account.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS accounts (
-    uuid TEXT NOT NULL,
+    uuid TEXT NOT NULL UNIQUE,
     password TEXT NOT NULL,
     current_join DATE,
 

--- a/db/src/migrations/02_create-account.sql
+++ b/db/src/migrations/02_create-account.sql
@@ -3,6 +3,6 @@ CREATE TABLE IF NOT EXISTS accounts (
     password TEXT NOT NULL,
     current_join DATE,
 
-    FOREIGN KEY (uuid) REFERENCES user(uuid),
+    FOREIGN KEY (uuid) REFERENCES users(uuid),
     PRIMARY KEY (uuid)
 );

--- a/db/src/migrations/03_create-allowlist.sql
+++ b/db/src/migrations/03_create-allowlist.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS allowlist (
-    uuid TEXT NOT NULL,
+    uuid TEXT NOT NULL UNIQUE,
     discord_id TEXT NOT NULL,
     base_ip INTEGER NOT NULL,
     mask INTEGER NOT NULL,

--- a/db/src/migrations/03_create-allowlist.sql
+++ b/db/src/migrations/03_create-allowlist.sql
@@ -5,6 +5,6 @@ CREATE TABLE IF NOT EXISTS allowlist (
     last_join DATE,
     hits INTEGER,
 
-    FOREIGN KEY (uuid) REFERENCES users(uuid),
+    FOREIGN KEY (uuid) REFERENCES accounts(uuid) ON UPDATE CASCADE,
     PRIMARY KEY (uuid, last_join)
 );

--- a/db/src/migrations/03_create-allowlist.sql
+++ b/db/src/migrations/03_create-allowlist.sql
@@ -1,11 +1,10 @@
 CREATE TABLE IF NOT EXISTS allowlist (
     uuid TEXT NOT NULL UNIQUE,
-    discord_id TEXT NOT NULL,
     base_ip INTEGER NOT NULL,
     mask INTEGER NOT NULL,
     last_join DATE,
     hits INTEGER,
 
-    FOREIGN KEY (uuid, discord_id) REFERENCES users(uuid, discord_id),
+    FOREIGN KEY (uuid) REFERENCES users(uuid),
     PRIMARY KEY (uuid, last_join)
 );

--- a/db/src/migrations/03_create-allowlist.sql
+++ b/db/src/migrations/03_create-allowlist.sql
@@ -6,5 +6,5 @@ CREATE TABLE IF NOT EXISTS allowlist (
     hits INTEGER,
 
     FOREIGN KEY (uuid) REFERENCES accounts(uuid) ON UPDATE CASCADE,
-    PRIMARY KEY (uuid, last_join)
+    PRIMARY KEY (uuid, base_ip, mask)
 );

--- a/db/src/migrations/03_create-allowlist.sql
+++ b/db/src/migrations/03_create-allowlist.sql
@@ -1,10 +1,11 @@
 CREATE TABLE IF NOT EXISTS allowlist (
     uuid TEXT NOT NULL,
+    discord_id TEXT NOT NULL,
     base_ip INTEGER NOT NULL,
     mask INTEGER NOT NULL,
     last_join DATE,
     hits INTEGER,
 
-    FOREIGN KEY (uuid) REFERENCES users(uuid),
+    FOREIGN KEY (uuid, discord_id) REFERENCES users(uuid, discord_id),
     PRIMARY KEY (uuid, last_join)
 );

--- a/db/src/migrations/03_create-allowlist.sql
+++ b/db/src/migrations/03_create-allowlist.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS allowlist (
-    uuid TEXT NOT NULL UNIQUE,
+    uuid TEXT NOT NULL,
     base_ip INTEGER NOT NULL,
     mask INTEGER NOT NULL,
     last_join DATE,

--- a/db/src/migrations/03_create-allowlist.sql
+++ b/db/src/migrations/03_create-allowlist.sql
@@ -5,6 +5,6 @@ CREATE TABLE IF NOT EXISTS allowlist (
     last_join DATE,
     hits INTEGER,
 
-    FOREIGN KEY (uuid) REFERENCES user(uuid),
+    FOREIGN KEY (uuid) REFERENCES users(uuid),
     PRIMARY KEY (uuid, last_join)
 );

--- a/db/src/migrations/04_create-blacklist.sql
+++ b/db/src/migrations/04_create-blacklist.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS blacklist (
     base_ip INTEGER UNIQUE,
-    mask INTEGER UNIQUE,
+    mask INTEGER,
     created_at DATE,
     actor TEXT NOT NULL,
     hits INTEGER, 

--- a/db/src/migrations/06_create-savedata.sql
+++ b/db/src/migrations/06_create-savedata.sql
@@ -1,11 +1,12 @@
 CREATE TABLE IF NOT EXISTS savedata (
     server_uuid TEXT,
     player_uuid TEXT,
+    player_discord_id TEXT,
     playtime TEXT,
     viewport TEXT,
 
-    FOREIGN KEY (server_uuid) REFERENCES server(uuid),
-    FOREIGN KEY (player_uuid) REFERENCES user(uuid),
+    FOREIGN KEY (server_uuid) REFERENCES servers (uuid),
+    FOREIGN KEY (player_uuid, player_discord_id) REFERENCES users (uuid, discord_id),
 
     PRIMARY KEY (server_uuid, player_uuid)
 );

--- a/db/src/migrations/06_create-savedata.sql
+++ b/db/src/migrations/06_create-savedata.sql
@@ -1,12 +1,11 @@
 CREATE TABLE IF NOT EXISTS savedata (
     server_uuid TEXT,
     player_uuid TEXT,
-    player_discord_id TEXT,
     playtime TEXT,
     viewport TEXT,
 
     FOREIGN KEY (server_uuid) REFERENCES servers (uuid),
-    FOREIGN KEY (player_uuid, player_discord_id) REFERENCES users (uuid, discord_id),
+    FOREIGN KEY (player_uuid) REFERENCES users (uuid),
 
     PRIMARY KEY (server_uuid, player_uuid)
 );

--- a/db/src/tests/sqlite.rs
+++ b/db/src/tests/sqlite.rs
@@ -8,6 +8,16 @@ async fn get_wrapper(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<Sqlite> {
     Ok(Sqlite::new(pool.acquire().await?.detach()))
 }
 
+fn offline_uuid(name: &'static str) -> Uuid {
+    let string = "OfflinePlayer:".to_owned() + name;
+    let mut hash = md5::compute(string).0;
+
+    hash[6] = hash[6] & 0x0f | 0x30; // uuid version 3
+    hash[8] = hash[8] & 0x3f | 0x80; // RFC4122 variant
+
+    Uuid::from_bytes(hash)
+}
+
 // CREATE
 
 #[test(sqlx::test(migrations = "src/migrations"))]

--- a/db/src/tests/sqlite.rs
+++ b/db/src/tests/sqlite.rs
@@ -1,1 +1,165 @@
 // Unit Tests for the Sqlite Driver.
+use test_log::test;
+use uuid::Uuid;
+
+use crate::{data::{stub::UserStub, Pronoun}, drivers::{err::{DriverError, Response}, sqlite::Sqlite}, interface::DataSource};
+
+async fn get_wrapper(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<Sqlite> {
+    Ok(Sqlite::new(pool.acquire().await?.detach()))
+}
+
+// CREATE
+
+#[test(sqlx::test(migrations = "src/migrations"))]
+async fn create_user(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<()> {
+    let uuid = Uuid::new_v4();
+    let mut db = get_wrapper(pool).await.unwrap();
+
+    let stub = UserStub {
+        uuid: uuid.clone(),
+        username: "alikindsys".to_owned(),
+        discord_id: "-Discord ID-".to_owned(),
+    };
+
+    let save = db.create_user(stub.clone()).await.unwrap();
+
+    assert_eq!(stub, save);
+    Ok(())
+}
+
+// READ
+#[test(sqlx::test(migrations = "src/migrations"))]
+async fn get_user_by_uuid(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<()> {
+    let uuid = Uuid::new_v4();
+    let mut db = get_wrapper(pool).await.unwrap();
+
+    let stub = UserStub {
+        uuid: uuid.clone(),
+        username: "alikindsys".to_owned(),
+        discord_id: "-Discord ID-".to_owned(),
+    };
+
+    db.create_user(stub.clone()).await.unwrap();
+    let save = db.get_user_by_uuid(&uuid).await.unwrap();
+
+    assert_eq!(stub, save);
+    Ok(())
+}
+
+#[test(sqlx::test(migrations = "src/migrations"))]
+async fn get_users_by_discord_id(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<()> {
+    let discord_id = "-Discord ID-".to_owned();
+    let mut db = get_wrapper(pool).await.unwrap();
+
+    let stub = UserStub {
+        uuid: Uuid::new_v4(),
+        username: "alikindsys".to_owned(),
+        discord_id: discord_id.clone(),
+    };
+
+    let stub2 = UserStub {
+        uuid: Uuid::new_v4(),
+        username: "another_user".to_owned(),
+        discord_id: discord_id.clone(),
+    };
+
+
+    db.create_user(stub).await.unwrap();
+    db.create_user(stub2).await.unwrap();
+    let save = db.get_users_by_discord_id(discord_id).await.unwrap();
+
+    assert_eq!(save.len(), 2);
+    Ok(())
+}
+
+// UPDATE
+
+#[test(sqlx::test(migrations = "src/migrations"))]
+async fn add_pronoun(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<()> {
+    let uuid = Uuid::new_v4();
+    let mut db = get_wrapper(pool).await.unwrap();
+
+    let stub = UserStub {
+        uuid: uuid.clone(),
+        username: "alikindsys".to_owned(),
+        discord_id: "-Discord ID-".to_owned(),
+    };
+
+    let pronoun = Pronoun { pronoun: "ela/dela".to_owned(), color: "#F5A9B8".to_owned() };
+
+    db.create_user(stub.clone()).await.unwrap();
+    let pronouns = db.add_pronoun(&uuid, pronoun).await.unwrap();
+
+    assert_eq!(pronouns.len(), 1);
+
+    Ok(())
+}
+
+#[test(sqlx::test(migrations = "src/migrations"))]
+async fn remove_pronoun(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<()> {
+    let uuid = Uuid::new_v4();
+    let mut db = get_wrapper(pool).await.unwrap();
+
+    let stub = UserStub {
+        uuid: uuid.clone(),
+        username: "alikindsys".to_owned(),
+        discord_id: "-Discord ID-".to_owned(),
+    };
+
+    let pronoun = Pronoun { pronoun: "ela/dela".to_owned(), color: "#F5A9B8".to_owned() };
+
+    db.create_user(stub.clone()).await.unwrap();
+    db.add_pronoun(&uuid, pronoun.clone()).await.unwrap();
+
+    let pronouns = db.remove_pronoun(&uuid, pronoun).await.unwrap();
+
+    assert_eq!(pronouns.len(), 0);
+
+    Ok(())
+}
+
+#[test(sqlx::test(migrations = "src/migrations"))]
+async fn update_pronoun(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<()> {
+    let uuid = Uuid::new_v4();
+    let mut db = get_wrapper(pool).await.unwrap();
+
+    let stub = UserStub {
+        uuid: uuid.clone(),
+        username: "alikindsys".to_owned(),
+        discord_id: "-Discord ID-".to_owned(),
+    };
+
+    let pronoun = Pronoun { pronoun: "ela/dela".to_owned(), color: "#F5A9B8".to_owned() };
+    let update = Pronoun { pronoun: "ela/dela".to_owned(), color: "#5BCEFA".to_owned()};
+
+    db.create_user(stub.clone()).await.unwrap();
+    db.add_pronoun(&uuid, pronoun.clone()).await.unwrap();
+
+    let pronouns = db.update_pronoun(&uuid, &pronoun, update.clone()).await.unwrap();
+
+    assert_eq!(pronouns.get(0).unwrap().color, update.color);
+    assert_eq!(pronouns.len(), 1);
+
+    Ok(())
+}
+
+// DELETE
+
+#[test(sqlx::test(migrations = "src/migrations"))]
+async fn delete_user(pool: sqlx::Pool<sqlx::Sqlite>) -> sqlx::Result<()> {
+    let uuid = Uuid::new_v4();
+    let mut db = get_wrapper(pool).await.unwrap();
+
+    let stub = UserStub {
+        uuid: uuid.clone(),
+        username: "alikindsys".to_owned(),
+        discord_id: "-Discord ID-".to_owned(),
+    };
+
+    db.create_user(stub.clone()).await.unwrap();
+    let save = db.delete_user(&uuid).await.unwrap();
+
+    assert_eq!(stub, save);
+    Ok(())
+}
+


### PR DESCRIPTION
## Funcionalidade testada - Na branch `db/testing`: 
> [!NOTE]
> Assim que todas as funções tiverem sido testadas, e os fixes da `db/testing` forem incorporados nessa branch com um merge commit, esse pull request pode ser mesclado.
### User 
- [x] Create - 991085cee1439ca887f7d38cd249de58108009db
- [x] Get by UUID - 991085cee1439ca887f7d38cd249de58108009db
- [x] Get by Discord Id - 991085cee1439ca887f7d38cd249de58108009db
- [x] Delete - 991085cee1439ca887f7d38cd249de58108009db
- [x] Migrate - debaadf46aec1bfc301efca32754c1947d1f7c21

### Account
- [x] Create - 021ddd669c4224b6847a676eb922abd91806f4cf
- [x] Get - 021ddd669c4224b6847a676eb922abd91806f4cf
- [x] Update Password - 021ddd669c4224b6847a676eb922abd91806f4cf
- [x] Migrate - 021ddd669c4224b6847a676eb922abd91806f4cf
- [x] Delete - 021ddd669c4224b6847a676eb922abd91806f4cf

### Allowlist 
- [x] Create - 7b36f9a81ccb1d2c0ab248ed14e2eefa4f9caa1b
- [x] Get For Player - 7b36f9a81ccb1d2c0ab248ed14e2eefa4f9caa1b
- [x] Get For Player With IP - 7b36f9a81ccb1d2c0ab248ed14e2eefa4f9caa1b
- [x] Get For Player With Range - 7b36f9a81ccb1d2c0ab248ed14e2eefa4f9caa1b
- [x] Bump - 7b36f9a81ccb1d2c0ab248ed14e2eefa4f9caa1b
- [x] Broaden Mask - 7b36f9a81ccb1d2c0ab248ed14e2eefa4f9caa1b
- [x] Delete - 7b36f9a81ccb1d2c0ab248ed14e2eefa4f9caa1b

### Blacklist 
- [x] Create - 45757808f0ae1da46ae555a99d9fe4ab637159ec
- [x] Get For IP - 45757808f0ae1da46ae555a99d9fe4ab637159ec
- [x] Get For Range - 45757808f0ae1da46ae555a99d9fe4ab637159ec
- [x] Bump - 45757808f0ae1da46ae555a99d9fe4ab637159ec
- [x] Broaden Mask - 45757808f0ae1da46ae555a99d9fe4ab637159ec
- [x] Delete - 45757808f0ae1da46ae555a99d9fe4ab637159ec


### Server
- [x] Create - add9efa10cc3672689ae098ac903d39a629b4c3c
- [x] Get by UUID - add9efa10cc3672689ae098ac903d39a629b4c3c
- [x] Get by Name - add9efa10cc3672689ae098ac903d39a629b4c3c
- [x] Delete - add9efa10cc3672689ae098ac903d39a629b4c3c
- [x] Join - add9efa10cc3672689ae098ac903d39a629b4c3c
- [x] Leave - add9efa10cc3672689ae098ac903d39a629b4c3c

### Viewport (Userdata)
- [x] Update - 05274f8e900000fc288b4e7aa10fd9e2a7ab0356
- [x] Get - 05274f8e900000fc288b4e7aa10fd9e2a7ab0356

### Playtime (Userdata)
- [x] Update - 05274f8e900000fc288b4e7aa10fd9e2a7ab0356
- [x] Get - 05274f8e900000fc288b4e7aa10fd9e2a7ab0356

### Pronouns (User)
- [x] Add - 991085cee1439ca887f7d38cd249de58108009db
- [x] Remove - 991085cee1439ca887f7d38cd249de58108009db
- [x] Update - 991085cee1439ca887f7d38cd249de58108009db

### Savedata
- [x] Create - 05274f8e900000fc288b4e7aa10fd9e2a7ab0356